### PR TITLE
Fix to content offset losing one parameter

### DIFF
--- a/RAPageViewController/RAPageCollectionViewController.m
+++ b/RAPageViewController/RAPageCollectionViewController.m
@@ -433,13 +433,13 @@ static NSString * const RAPageCollectionViewDidEndScrollAnimationNotification = 
 		
 		case UICollectionViewScrollDirectionHorizontal: {
 			pageBreadth = layout.itemSize.width + [self pageSpacing];
-			toContentOffset = (CGPoint) { .x = displayIndex * pageBreadth };
+			toContentOffset = (CGPoint) { .x = displayIndex * pageBreadth, .y = self.collectionView.contentOffset.y };
 			break;
 		}
 		
 		case UICollectionViewScrollDirectionVertical: {
 			pageBreadth = layout.itemSize.height + [self pageSpacing];
-			toContentOffset = (CGPoint) { .y = displayIndex * pageBreadth };
+			toContentOffset = (CGPoint) { .y = displayIndex * pageBreadth, .x = self.collectionView.contentOffset.x };
 			break;
 		}
 		


### PR DESCRIPTION
Used RAPAgeCollectionViewController to present few table view controllers and met that flow layout was telling me all the time that height of object in cell must be less than collectionView height and it's edge insets but that no problem. The problem was that on every time when i use setDisplayIndex collection view moved up and thats because at the lines i changed toContentOffset has no y or x depending on flowLayout direction which resulted it to animate movement to toContentOffset which doesn't have one parameter and that don't seem ok. As a result of these i have no more logging about flowLayout and scrollView contentOffset animated correctly.
